### PR TITLE
Generic modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-synthea_rules.png
+*.png
 fhir*.log
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'synthea', :path => '../synthea/'
 gem 'health-data-standards', :git => 'https://github.com/projectcypress/health-data-standards.git', :branch => 'master'
-
+gem 'net-sftp'
 gem 'ruby-graphviz'
 gem 'pry'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ PATH
       faker (~> 1.6, >= 1.6.0)
       fhir_client
       fhir_models
+      georuby
       pickup (~> 0.0.11, >= 0.0.11)
       recursive-open-struct (~> 1.0, >= 1.0.0)
 
@@ -61,7 +62,7 @@ GEM
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    faker (1.6.3)
+    faker (1.6.6)
       i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -79,12 +80,13 @@ GEM
       mime-types (>= 1.16, < 3)
       nokogiri (>= 1.6)
       rake (>= 0.8.7)
+    georuby (2.5.2)
     highline (1.7.8)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
-    jwt (1.5.1)
+    jwt (1.5.4)
     log4r (1.1.10)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
@@ -107,12 +109,15 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    net-sftp (2.1.2)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.2.0)
     netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
-    oauth2 (1.1.0)
+    oauth2 (1.2.0)
       faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0, < 1.5.2)
+      jwt (~> 1.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
@@ -151,6 +156,7 @@ PLATFORMS
 
 DEPENDENCIES
   health-data-standards!
+  net-sftp
   pry
   ruby-graphviz
   synthea!

--- a/synthea_graphviz.rb
+++ b/synthea_graphviz.rb
@@ -6,70 +6,180 @@ require 'synthea'
 # color (true) or black & white (false)
 COLOR = true
 
-# Create a new graph
-g = GraphViz.new( :G, :type => :digraph )
+def generateRulesBasedGraph()
+  # Create a new graph
+  g = GraphViz.new( :G, :type => :digraph )
 
-# Create the list of items
-items = []
-modules = {}
-Synthea::Rules.metadata.each do |key,rule|
-  items << key
-  items << rule[:inputs]
-  items << rule[:outputs]
-  modules[ rule[:module_name] ] = true
-end
-items = items.flatten.uniq
-
-# Choose a color for each module
-# available_colors = GraphViz::Utils::Colors::COLORS.keys
-available_colors = ['palevioletred','orange','lightgoldenrod','palegreen','lightblue','lavender','purple']
-modules.keys.each_with_index do |key,index|
-  modules[key] = available_colors[index]
-end
-attribute_color = 'grey'
-
-# Create a node for each item
-nodes = {}
-items.each{|i|nodes[i]=g.add_node(i.to_s)}
-
-# Make items that are not rules boxes
-components = nodes.keys - Synthea::Rules.metadata.keys
-components.each do |i|
-  nodes[i]['shape']='Box'
-  if COLOR
-    nodes[i]['color']=attribute_color
-    nodes[i]['style']='filled'
+  # Create the list of items
+  items = []
+  modules = {}
+  Synthea::Rules.metadata.each do |key,rule|
+    items << key
+    items << rule[:inputs]
+    items << rule[:outputs]
+    modules[ rule[:module_name] ] = true
   end
+  items = items.flatten.uniq
+
+  # Choose a color for each module
+  # available_colors = GraphViz::Utils::Colors::COLORS.keys
+  available_colors = ['palevioletred','orange','lightgoldenrod','palegreen','lightblue','lavender','purple']
+  modules.keys.each_with_index do |key,index|
+    modules[key] = available_colors[index]
+  end
+  attribute_color = 'grey'
+
+  # Create a node for each item
+  nodes = {}
+  items.each{|i|nodes[i]=g.add_node(i.to_s)}
+
+  # Make items that are not rules boxes
+  components = nodes.keys - Synthea::Rules.metadata.keys
+  components.each do |i|
+    nodes[i]['shape']='Box'
+    if COLOR
+      nodes[i]['color']=attribute_color
+      nodes[i]['style']='filled'
+    end
+  end
+
+  # Create the edges
+  edges = []
+
+  Synthea::Rules.metadata.each do |key,rule|
+    node = nodes[key]
+    if COLOR
+      node['color'] = modules[rule[:module_name]]
+      node['style'] = 'filled'
+    end
+    begin
+      rule[:inputs].each do |input|
+        other = nodes[input]
+        if !edges.include?("#{input}:#{key}")
+          g.add_edge( other, node)
+          edges << "#{input}:#{key}"
+        end
+      end
+      rule[:outputs].each do |output|
+        other = nodes[output]
+        if !edges.include?("#{key}:#{output}")
+          g.add_edge( node, other)
+          edges << "#{key}:#{output}"
+        end
+      end
+    rescue Exception => e
+      binding.pry
+    end
+  end
+
+  # Generate output image
+  g.output( :png => "synthea_rules.png" )
 end
 
-# Create the edges
-edges = []
+def generateWorkflowBasedGraphs()
+  Dir.glob('../synthea/lib/generic/modules/*.json') do |wf_file|
+    # Create a new graph
+    g = GraphViz.new( :G, :type => :digraph )
 
-Synthea::Rules.metadata.each do |key,rule|
-  node = nodes[key]
-  if COLOR
-    node['color'] = modules[rule[:module_name]]
-    node['style'] = 'filled'
-  end
-  begin
-    rule[:inputs].each do |input|
-      other = nodes[input]
-      if !edges.include?("#{input}:#{key}")
-        g.add_edge( other, node)
-        edges << "#{input}:#{key}"
+    # Create nodes based on states
+    nodeMap = {}
+    wf = JSON.parse(File.read(wf_file))
+    wf['states'].each do |name, state|
+      node = g.add_nodes(name, {'shape': 'record', 'style': 'rounded'})
+      details = ''
+      case state['type']
+      when 'Initial', 'Terminal'
+        node['color'] = 'black'
+        node['style'] = 'rounded,filled'
+        node['fontcolor'] = 'white'
+      when 'Guard'
+        details = logicDetails(state['if'])
+      when 'Delay'
+        if state.has_key? 'range'
+          r = state['range']
+          details = "#{r['low']} - #{r['high']} #{r['unit']}"
+        elsif state.has_key? 'exact'
+          e = state['exact']
+          details = "#{r['quantity']} #{r['unit']}"
+        end 
+      when 'Encounter'
+        if state['wellness']
+          details = 'Wait for regularly scheduled wellness encounter'
+        end       
+      end
+
+      # Things common to many states
+      if state.has_key? 'codes'
+        state['codes'].each do |code|
+          details = details + code['system'] + "[" + code['code'] + "]: " + code['display'] + "\\l"
+        end
+      end
+      if state.has_key? 'target_encounter'
+        verb = 'Perform'
+        case state['type']
+        when 'ConditionOnset'
+          verb = 'Diagnose'
+        when 'MedicationOrder'
+          verb = 'Prescribe'
+        end
+        details = details + verb + " at " + state['target_encounter'] + "\\l"
+      end
+      if state.has_key? 'reason'
+        details = details + "Reason: " + state['reason'] + "\\l"
+      end
+      node['label'] = details.empty? ? "{ #{name} | #{state['type']} }" : "{ #{name} | { #{state['type']} | #{details} } }"
+      nodeMap[name] = node
+    end
+
+    # Create the edges based on the transitions
+    wf['states'].each do |name, state|
+      if state.has_key? 'direct_transition'
+        g.add_edges( nodeMap[name], nodeMap[state['direct_transition']] )
+      elsif state.has_key? 'distributed_transition'
+        state['distributed_transition'].each do |t|
+          pct = t['distribution'] * 100
+          pct = pct.to_i if pct == pct.to_i
+          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "#{pct}%"})
+        end
       end
     end
-    rule[:outputs].each do |output|
-      other = nodes[output]
-      if !edges.include?("#{key}:#{output}")
-        g.add_edge( node, other)
-        edges << "#{key}:#{output}"
-      end
-    end
-  rescue Exception => e
-    binding.pry
+
+    # Generate output image
+    g.output( :png => "#{wf['name']}.png" )
   end
 end
 
-# Generate output image
-g.output( :png => "synthea_rules.png" )
+def workflowNodeLabel(name, type, details = "")
+  "{ #{name} | { #{type} | #{details} } }"
+end
+
+def logicDetails(logic)
+  case logic['condition_type']
+  when 'And', 'Or'
+    subs = logic['conditions'].map do |c|
+      if ['And','Or'].include?(c['condition_type'])
+        "(\\l" + logicDetails(c) + ")\\l"
+      else 
+        logicDetails(c)
+      end
+    end
+    subs.join(logic['condition_type'].downcase + ' ')
+  when 'Not'
+    c = logic['condition']
+    if ['And','Or'].include?(c['condition_type'])
+      "not (\\l" + logicDetails(c) + ")\\l"
+    else
+      "not " + logicDetails(c)
+    end
+  when 'Gender'
+    "gender is '#{logic['gender']}'\\l"
+  when 'Age'
+    "age \\#{logic['operator']} #{logic['quantity']} #{logic['unit']}\\l"
+  else
+    "UNSUPPORTED_CONDITION(#{logic['condition_type']})\\l"
+  end
+end
+
+generateRulesBasedGraph()
+generateWorkflowBasedGraphs()
+

--- a/synthea_graphviz.rb
+++ b/synthea_graphviz.rb
@@ -93,7 +93,7 @@ def generateWorkflowBasedGraphs()
         node['style'] = 'rounded,filled'
         node['fontcolor'] = 'white'
       when 'Guard'
-        details = logicDetails(state['if'])
+        details = logicDetails(state['allow'])
       when 'Delay'
         if state.has_key? 'range'
           r = state['range']
@@ -140,6 +140,11 @@ def generateWorkflowBasedGraphs()
           pct = t['distribution'] * 100
           pct = pct.to_i if pct == pct.to_i
           g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "#{pct}%"})
+        end
+      elsif state.has_key? 'conditional_transition'
+        state['conditional_transition'].each_with_index do |t,i|
+          cnd = t.has_key?('condition') ? logicDetails(t['condition']) : 'fallback'
+          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "[#{i}] #{cnd}"})
         end
       end
     end

--- a/synthea_graphviz.rb
+++ b/synthea_graphviz.rb
@@ -93,7 +93,7 @@ def generateWorkflowBasedGraphs()
         node['style'] = 'rounded,filled'
         node['fontcolor'] = 'white'
       when 'Guard'
-        details = logicDetails(state['allow'])
+        details = "Allow if " + logicDetails(state['allow'])
       when 'Delay'
         if state.has_key? 'range'
           r = state['range']
@@ -127,7 +127,11 @@ def generateWorkflowBasedGraphs()
       if state.has_key? 'reason'
         details = details + "Reason: " + state['reason'] + "\\l"
       end
-      node['label'] = details.empty? ? "{ #{name} | #{state['type']} }" : "{ #{name} | { #{state['type']} | #{details} } }"
+      if details.empty?
+        node['label'] = (name == state['type']) ? name : "{ #{name} | #{state['type']} }"
+      else
+        node['label'] = "{ #{name} | { #{state['type']} | #{details} } }"
+      end
       nodeMap[name] = node
     end
 
@@ -143,8 +147,8 @@ def generateWorkflowBasedGraphs()
         end
       elsif state.has_key? 'conditional_transition'
         state['conditional_transition'].each_with_index do |t,i|
-          cnd = t.has_key?('condition') ? logicDetails(t['condition']) : 'fallback'
-          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "[#{i}] #{cnd}"})
+          cnd = t.has_key?('condition') ? logicDetails(t['condition']) : 'else'
+          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "#{i+1}. #{cnd}"})
         end
       end
     end
@@ -152,10 +156,6 @@ def generateWorkflowBasedGraphs()
     # Generate output image
     g.output( :png => "#{wf['name']}.png" )
   end
-end
-
-def workflowNodeLabel(name, type, details = "")
-  "{ #{name} | { #{type} | #{details} } }"
 end
 
 def logicDetails(logic)

--- a/synthea_graphviz.rb
+++ b/synthea_graphviz.rb
@@ -85,7 +85,7 @@ def generateWorkflowBasedGraphs()
     nodeMap = {}
     wf = JSON.parse(File.read(wf_file))
     wf['states'].each do |name, state|
-      node = g.add_nodes(name, {'shape': 'record', 'style': 'rounded'})
+      node = g.add_nodes(name, {'shape'=> 'record', 'style'=> 'rounded'})
       details = ''
       case state['type']
       when 'Initial', 'Terminal'
@@ -143,12 +143,12 @@ def generateWorkflowBasedGraphs()
         state['distributed_transition'].each do |t|
           pct = t['distribution'] * 100
           pct = pct.to_i if pct == pct.to_i
-          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "#{pct}%"})
+          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label'=> "#{pct}%"})
         end
       elsif state.has_key? 'conditional_transition'
         state['conditional_transition'].each_with_index do |t,i|
           cnd = t.has_key?('condition') ? logicDetails(t['condition']) : 'else'
-          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label': "#{i+1}. #{cnd}"})
+          g.add_edges( nodeMap[name], nodeMap[t['transition']], {'label'=> "#{i+1}. #{cnd}"})
         end
       end
     end


### PR DESCRIPTION
This PR corresponds with https://github.com/synthetichealth/synthea/pull/14.  It provides the capability for graph_viz to generate graphs of generically defined modules.

The diff looks pretty bad, but that's because I moved the existing graph code into its own function.  This changed the indent level of that code, and thus, the diff highlights nearly every line.  If you do a diff ignoring whitespace, you'll see I didn't change any of the existing graphing logic.  I only added new logic.
